### PR TITLE
Fix bugs in autoload lisp

### DIFF
--- a/readme.org
+++ b/readme.org
@@ -109,7 +109,7 @@ Furthermore we're using the EDE autoload mechanism to automatically create and l
     (let ((default-directory dir)
           (config-and-dir (car (cl-member-if (lambda (c)
                                                (file-readable-p
-                                                (expand-file-name "compile_commands.json" (cdr c))))
+                                                (expand-file-name "compile_commands.json" (concat dir (cdr c)))))
                                              my-cmake-build-directories))))
       (unless config-and-dir
         (error "Couldn't determine build directory for project at %s" dir))
@@ -127,7 +127,7 @@ Furthermore we're using the EDE autoload mechanism to automatically create and l
   (defun vc-project-root (dir)
     (require 'vc)
     (let* ((default-directory dir)
-           (backend (vc-deduce-backend)))
+           (backend (vc-responsible-backend dir)))
       (and backend (vc-call-backend backend 'root default-directory))))
 
   (ede-add-project-autoload


### PR DESCRIPTION
In  my-load-cmake-project, expand-file-name only uses default-directory if the second argument is nil.
Otherwise, it uses the second argument as the default directory, and since it's a relative name, you end up with some randomness, sometimes right, and sometimes wrong.
Fixed by concat'ing dir and that path, which will give the right place.

In vc-project-root, you want vc-responsible-backend, vc-deduce-backend doesn't do what we want.

With these two fixes, it does proper autoloading on emacs 24.4 and emacs 24.5 dev.